### PR TITLE
Add pluggable image provider system with root filesystem support

### DIFF
--- a/PLUGGABLE_IMAGES.md
+++ b/PLUGGABLE_IMAGES.md
@@ -1,0 +1,170 @@
+# Pluggable Image Providers for CRI-O
+
+This document describes the implementation of pluggable image providers in CRI-O, enabling support for different image types beyond standard container images.
+
+## Overview
+
+The pluggable image provider system allows CRI-O to handle different image schemes and sources through a provider-based architecture. This enables support for:
+
+- Root filesystem directories (`root-fs://` scheme)
+- Future custom image sources
+- Extensible image handling without modifying core CRI-O code
+
+## Architecture
+
+### Components
+
+1. **ImageProvider Interface** (`internal/imageprovider/interface.go`)
+   - Defines the contract for image providers
+   - Handles image operations: pull, status, remove, list
+
+2. **RootFS Provider** (`internal/imageprovider/rootfs.go`)
+   - Implements support for local filesystem directories
+   - Handles `root-fs://` scheme URLs
+   - Provides path validation and security controls
+
+3. **Default Provider** (`internal/imageprovider/default.go`)
+   - Wraps existing CRI-O image functionality
+   - Handles standard container images (docker://, etc.)
+
+4. **Service** (`internal/imageprovider/service.go`)
+   - Manages provider registry
+   - Routes requests to appropriate providers
+
+### Configuration
+
+Image providers are configured in the CRI-O configuration file under the `[crio.image.image_providers]` section:
+
+```toml
+[crio.image]
+# Enable pluggable image providers
+[crio.image.image_providers]
+enable_pluggable_providers = true
+
+# Root filesystem provider configuration
+[crio.image.image_providers.rootfs]
+enable = true
+allowed_paths = [
+    "/opt/containers",
+    "/var/lib/crio-rootfs-images"
+]
+```
+
+## Usage
+
+### Root Filesystem Images
+
+With the root filesystem provider enabled, you can reference local directories as container images:
+
+```yaml
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: my-app
+    image: "root-fs:///opt/my-containers/my-app"
+```
+
+The directory at `/opt/my-containers/my-app` will be used directly as the container's root filesystem.
+
+### Security Considerations
+
+- **Path Restrictions**: The `allowed_paths` configuration restricts which directories can be used
+- **Validation**: The provider validates that paths exist and are directories
+- **Absolute Paths**: Only absolute paths are supported for security
+
+## Implementation Details
+
+### Image Provider Interface
+
+```go
+type ImageProvider interface {
+    Name() string
+    CanHandle(imageSpec *criv1.ImageSpec) bool
+    PullImage(ctx context.Context, imageSpec *criv1.ImageSpec, options *ImageProviderOptions) (*ImageProviderResult, error)
+    ImageStatus(ctx context.Context, imageSpec *criv1.ImageSpec) (*ImageProviderResult, error)
+    RemoveImage(ctx context.Context, imageSpec *criv1.ImageSpec) error
+    ListImages(ctx context.Context) ([]*ImageProviderResult, error)
+}
+```
+
+### Provider Selection
+
+The system selects providers based on the `CanHandle()` method. For root filesystem images:
+
+```go
+func (p *RootFSProvider) CanHandle(imageSpec *criv1.ImageSpec) bool {
+    return strings.HasPrefix(imageSpec.GetImage(), "root-fs://")
+}
+```
+
+### Integration Points
+
+The pluggable system integrates with existing CRI-O image operations:
+
+1. **PullImage** - Modified to use provider service when enabled
+2. **ImageStatus** - Routes to appropriate provider
+3. **RemoveImage** - Delegates to provider for handling
+4. **Server Initialization** - Registers and configures providers
+
+## Testing
+
+Example test setup:
+
+```bash
+# Create test directory
+mkdir -p /tmp/test-rootfs
+echo "Hello from rootfs" > /tmp/test-rootfs/hello.txt
+
+# Configure CRI-O with allowed path
+# [crio.image.image_providers.rootfs]
+# allowed_paths = ["/tmp"]
+
+# Use in pod spec
+# image: "root-fs:///tmp/test-rootfs"
+```
+
+## Future Extensibility
+
+The provider system is designed for easy extension:
+
+1. **New Providers**: Implement the `ImageProvider` interface
+2. **Registration**: Add provider registration in server initialization
+3. **Configuration**: Add provider-specific config sections
+
+Example new provider:
+
+```go
+type MyCustomProvider struct{}
+
+func (p *MyCustomProvider) CanHandle(imageSpec *criv1.ImageSpec) bool {
+    return strings.HasPrefix(imageSpec.GetImage(), "mycustom://")
+}
+```
+
+## Backward Compatibility
+
+- When pluggable providers are disabled, CRI-O uses existing image handling
+- Legacy image references work unchanged
+- No breaking changes to existing functionality
+- Gradual migration path for adopting new providers
+
+## Files Modified/Added
+
+### New Files
+- `internal/imageprovider/interface.go` - Core provider interface
+- `internal/imageprovider/service.go` - Provider management
+- `internal/imageprovider/rootfs.go` - Root filesystem provider
+- `internal/imageprovider/default.go` - Wrapper for existing functionality
+- `internal/imageprovider/util.go` - Utility functions
+- `server/image_provider_integration.go` - Integration with server
+
+### Modified Files
+- `pkg/config/config.go` - Added configuration structures
+- `pkg/config/template.go` - Added configuration templates
+- `server/server.go` - Added provider service initialization
+- `server/image_pull.go` - Added provider-aware pull logic
+- `server/image_status.go` - Added provider routing for status
+- `server/image_remove.go` - Added provider routing for removal
+
+This implementation provides a clean, extensible foundation for supporting diverse image sources in CRI-O while maintaining backward compatibility and security.

--- a/example_config.toml
+++ b/example_config.toml
@@ -1,0 +1,20 @@
+# Example CRI-O configuration with image providers enabled
+
+[crio.image]
+# Enable pluggable image providers for handling different image types.
+# When enabled, allows using custom image providers like root filesystem directories.
+[crio.image.image_providers]
+enable_pluggable_providers = true
+
+# Enable the root filesystem image provider for handling root-fs:// image references.
+# This allows containers to use local filesystem directories directly as root filesystems.
+[crio.image.image_providers.rootfs]
+enable = true
+
+# List of allowed base paths for root filesystem images.
+# If empty, any absolute path is allowed (not recommended for production).
+# Example: ["/opt/containers", "/var/lib/images"]
+allowed_paths = [
+	"/opt/my-containers",
+	"/var/lib/crio-rootfs-images",
+]

--- a/internal/imageprovider/default.go
+++ b/internal/imageprovider/default.go
@@ -1,0 +1,128 @@
+package imageprovider
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// DefaultProvider wraps the existing CRI-O image service functionality
+// It handles standard container images (docker://, containers-storage://, etc.)
+type DefaultProvider struct {
+	imageService storage.ImageServer
+}
+
+// NewDefaultProvider creates a new default image provider
+func NewDefaultProvider(imageService storage.ImageServer) *DefaultProvider {
+	return &DefaultProvider{
+		imageService: imageService,
+	}
+}
+
+// Name returns the provider name
+func (p *DefaultProvider) Name() string {
+	return "default"
+}
+
+// CanHandle checks if this provider can handle the given image spec
+// The default provider handles everything that doesn't have a specific provider
+func (p *DefaultProvider) CanHandle(imageSpec *criv1.ImageSpec) bool {
+	// Default provider can handle any image spec
+	return true
+}
+
+// PullImage pulls an image using the existing image service
+func (p *DefaultProvider) PullImage(ctx context.Context, imageSpec *criv1.ImageSpec, options *ImageProviderOptions) (*ImageProviderResult, error) {
+	// Convert ImageSpec to internal format
+	imageRef, err := parseImageSpecToReference(imageSpec)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Convert options to internal format
+	copyOptions := &storage.ImageCopyOptions{}
+	if options != nil {
+		copyOptions = convertToImageCopyOptions(options)
+	}
+	
+	// Pull the image using existing functionality
+	resultRef, err := p.imageService.PullImage(ctx, imageRef, copyOptions)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Get image status to fill in additional details
+	imageResult, err := p.imageService.ImageStatusByName(copyOptions.SourceCtx, resultRef)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &ImageProviderResult{
+		ImageRef: resultRef,
+		Size:     imageResult.Size,
+		Digest:   imageResult.Digest.String(),
+		Labels:   imageResult.Labels,
+		Metadata: map[string]string{
+			"provider": "default",
+		},
+	}, nil
+}
+
+// ImageStatus returns the status of an image using the existing image service
+func (p *DefaultProvider) ImageStatus(ctx context.Context, imageSpec *criv1.ImageSpec) (*ImageProviderResult, error) {
+	imageRef, err := parseImageSpecToReference(imageSpec)
+	if err != nil {
+		return nil, err
+	}
+	
+	imageResult, err := p.imageService.ImageStatusByName(nil, imageRef)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &ImageProviderResult{
+		ImageRef: *imageResult.SomeNameOfThisImage,
+		Size:     imageResult.Size,
+		Digest:   imageResult.Digest.String(),
+		Labels:   imageResult.Labels,
+		Metadata: map[string]string{
+			"provider": "default",
+		},
+	}, nil
+}
+
+// RemoveImage removes an image using the existing image service
+func (p *DefaultProvider) RemoveImage(ctx context.Context, imageSpec *criv1.ImageSpec) error {
+	imageRef, err := parseImageSpecToReference(imageSpec)
+	if err != nil {
+		return err
+	}
+	
+	return p.imageService.UntagImage(nil, imageRef)
+}
+
+// ListImages returns all images using the existing image service
+func (p *DefaultProvider) ListImages(ctx context.Context) ([]*ImageProviderResult, error) {
+	images, err := p.imageService.ListImages(nil)
+	if err != nil {
+		return nil, err
+	}
+	
+	results := make([]*ImageProviderResult, 0, len(images))
+	for _, img := range images {
+		if img.SomeNameOfThisImage != nil {
+			results = append(results, &ImageProviderResult{
+				ImageRef: *img.SomeNameOfThisImage,
+				Size:     img.Size,
+				Digest:   img.Digest.String(),
+				Labels:   img.Labels,
+				Metadata: map[string]string{
+					"provider": "default",
+				},
+			})
+		}
+	}
+	
+	return results, nil
+}

--- a/internal/imageprovider/interface.go
+++ b/internal/imageprovider/interface.go
@@ -1,0 +1,108 @@
+package imageprovider
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/containers/image/v5/types"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// ImageProvider defines the interface for pluggable image providers
+// Each provider handles a specific type of image reference scheme or runtime handler
+type ImageProvider interface {
+	// Name returns the unique name/identifier of this provider
+	Name() string
+
+	// CanHandle determines if this provider can handle the given image spec
+	// It should check the image reference scheme, runtime handler, or annotations
+	CanHandle(imageSpec *criv1.ImageSpec) bool
+
+	// PullImage pulls/prepares an image and returns a reference that can be used
+	// by the container runtime. The returned reference should be in a format
+	// that the storage layer can understand.
+	PullImage(ctx context.Context, imageSpec *criv1.ImageSpec, options *ImageProviderOptions) (*ImageProviderResult, error)
+
+	// ImageStatus returns the status of an image handled by this provider
+	ImageStatus(ctx context.Context, imageSpec *criv1.ImageSpec) (*ImageProviderResult, error)
+
+	// RemoveImage removes an image handled by this provider
+	RemoveImage(ctx context.Context, imageSpec *criv1.ImageSpec) error
+
+	// ListImages returns all images managed by this provider
+	ListImages(ctx context.Context) ([]*ImageProviderResult, error)
+}
+
+// ImageProviderOptions contains options for image operations
+type ImageProviderOptions struct {
+	// Auth configuration for pulling images
+	Auth *criv1.AuthConfig
+
+	// PodSandboxConfig for context (namespace, labels, etc.)
+	PodSandboxConfig *criv1.PodSandboxConfig
+
+	// SystemContext from the image service
+	SystemContext *types.SystemContext
+
+	// ProgressCallback for reporting pull progress
+	ProgressCallback func(types.ProgressProperties)
+}
+
+// ImageProviderResult represents the result of an image operation
+type ImageProviderResult struct {
+	// ImageRef is the canonical reference to the prepared image
+	// This should be in a format that CRI-O's storage layer can use
+	ImageRef storage.RegistryImageReference
+
+	// Size of the image in bytes (optional)
+	Size *uint64
+
+	// Digest of the image (optional)
+	Digest string
+
+	// Labels from the image config (optional)
+	Labels map[string]string
+
+	// Additional metadata specific to the provider
+	Metadata map[string]string
+}
+
+// Registry manages multiple image providers
+type Registry struct {
+	providers []ImageProvider
+	// Default provider for standard container images
+	defaultProvider ImageProvider
+}
+
+// NewRegistry creates a new provider registry
+func NewRegistry(defaultProvider ImageProvider) *Registry {
+	return &Registry{
+		providers:       make([]ImageProvider, 0),
+		defaultProvider: defaultProvider,
+	}
+}
+
+// Register adds a new image provider to the registry
+func (r *Registry) Register(provider ImageProvider) {
+	r.providers = append(r.providers, provider)
+}
+
+// FindProvider finds the appropriate provider for the given image spec
+func (r *Registry) FindProvider(imageSpec *criv1.ImageSpec) ImageProvider {
+	// Check registered providers first
+	for _, provider := range r.providers {
+		if provider.CanHandle(imageSpec) {
+			return provider
+		}
+	}
+	
+	// Fall back to default provider
+	return r.defaultProvider
+}
+
+// GetProviders returns all registered providers
+func (r *Registry) GetProviders() []ImageProvider {
+	result := make([]ImageProvider, len(r.providers))
+	copy(result, r.providers)
+	return result
+}

--- a/internal/imageprovider/rootfs.go
+++ b/internal/imageprovider/rootfs.go
@@ -1,0 +1,217 @@
+package imageprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	// RootFSScheme is the URL scheme for root filesystem images
+	RootFSScheme = "root-fs"
+	
+	// RootFSProviderName is the name of the root filesystem provider
+	RootFSProviderName = "root-fs"
+)
+
+// RootFSProvider implements ImageProvider for root filesystem directories
+// It handles image references like: root-fs:///opt/my-containers/my-image
+type RootFSProvider struct {
+	// allowedPaths contains the list of allowed base paths for security
+	allowedPaths []string
+}
+
+// NewRootFSProvider creates a new root filesystem image provider
+func NewRootFSProvider(allowedPaths []string) *RootFSProvider {
+	return &RootFSProvider{
+		allowedPaths: allowedPaths,
+	}
+}
+
+// Name returns the provider name
+func (p *RootFSProvider) Name() string {
+	return RootFSProviderName
+}
+
+// CanHandle checks if this provider can handle the given image spec
+func (p *RootFSProvider) CanHandle(imageSpec *criv1.ImageSpec) bool {
+	if imageSpec == nil {
+		return false
+	}
+	
+	// Check if the image reference uses the root-fs scheme
+	image := imageSpec.GetImage()
+	return strings.HasPrefix(image, RootFSScheme+"://")
+}
+
+// PullImage "pulls" a root filesystem image by validating the directory exists
+func (p *RootFSProvider) PullImage(ctx context.Context, imageSpec *criv1.ImageSpec, options *ImageProviderOptions) (*ImageProviderResult, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	rootfsPath, err := p.parseAndValidateImageRef(imageSpec.GetImage())
+	if err != nil {
+		return nil, fmt.Errorf("invalid root-fs image reference: %w", err)
+	}
+	
+	log.Infof(ctx, "Using root filesystem from: %s", rootfsPath)
+	
+	// Verify the path exists and is a directory
+	info, err := os.Stat(rootfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("root filesystem path does not exist: %s: %w", rootfsPath, err)
+	}
+	
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root filesystem path is not a directory: %s", rootfsPath)
+	}
+	
+	// Check if path is allowed
+	if !p.isPathAllowed(rootfsPath) {
+		return nil, fmt.Errorf("root filesystem path not allowed: %s", rootfsPath)
+	}
+	
+	// Create a storage reference that points to the root filesystem
+	// We'll use a special format that the storage layer can understand
+	imageRef, err := p.createImageReference(imageSpec.GetImage(), rootfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image reference: %w", err)
+	}
+	
+	// Calculate directory size (optional)
+	size := p.calculateDirectorySize(rootfsPath)
+	
+	// Create digest from path for uniqueness
+	pathDigest := digest.FromString(rootfsPath)
+	
+	return &ImageProviderResult{
+		ImageRef: imageRef,
+		Size:     size,
+		Digest:   pathDigest.String(),
+		Labels:   map[string]string{
+			"io.cri-o.image.provider": RootFSProviderName,
+		},
+		Metadata: map[string]string{
+			"rootfs.path": rootfsPath,
+			"rootfs.original_ref": imageSpec.GetImage(),
+		},
+	}, nil
+}
+
+// ImageStatus returns the status of a root filesystem image
+func (p *RootFSProvider) ImageStatus(ctx context.Context, imageSpec *criv1.ImageSpec) (*ImageProviderResult, error) {
+	// For root-fs images, status is the same as pull (just validation)
+	return p.PullImage(ctx, imageSpec, nil)
+}
+
+// RemoveImage removes a root filesystem image (no-op since it's just a directory)
+func (p *RootFSProvider) RemoveImage(ctx context.Context, imageSpec *criv1.ImageSpec) error {
+	// Root filesystem images are not "removed" since they're just directories
+	// We could potentially track them and "unregister" but for simplicity, this is a no-op
+	log.Infof(ctx, "Root filesystem image removal requested for: %s (no-op)", imageSpec.GetImage())
+	return nil
+}
+
+// ListImages returns all root filesystem images (not implemented for directories)
+func (p *RootFSProvider) ListImages(ctx context.Context) ([]*ImageProviderResult, error) {
+	// For directory-based images, listing is not straightforward
+	// Return empty list for now
+	return []*ImageProviderResult{}, nil
+}
+
+// parseAndValidateImageRef parses a root-fs:// URL and returns the filesystem path
+func (p *RootFSProvider) parseAndValidateImageRef(imageRef string) (string, error) {
+	if !strings.HasPrefix(imageRef, RootFSScheme+"://") {
+		return "", fmt.Errorf("invalid scheme, expected %s://", RootFSScheme)
+	}
+	
+	// Remove the scheme prefix
+	path := strings.TrimPrefix(imageRef, RootFSScheme+"://")
+	
+	if path == "" {
+		return "", errors.New("empty path in root-fs image reference")
+	}
+	
+	// Clean the path
+	path = filepath.Clean(path)
+	
+	// Ensure absolute path
+	if !filepath.IsAbs(path) {
+		return "", errors.New("root filesystem path must be absolute")
+	}
+	
+	return path, nil
+}
+
+// isPathAllowed checks if the given path is under an allowed base path
+func (p *RootFSProvider) isPathAllowed(path string) bool {
+	if len(p.allowedPaths) == 0 {
+		// If no restrictions configured, allow any absolute path
+		return true
+	}
+	
+	cleanPath := filepath.Clean(path)
+	
+	for _, allowedPath := range p.allowedPaths {
+		cleanAllowedPath := filepath.Clean(allowedPath)
+		
+		// Check if the path is under the allowed path
+		if strings.HasPrefix(cleanPath, cleanAllowedPath) {
+			return true
+		}
+	}
+	
+	return false
+}
+
+// calculateDirectorySize calculates the total size of a directory
+func (p *RootFSProvider) calculateDirectorySize(dirPath string) *uint64 {
+	var totalSize uint64
+	
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			totalSize += uint64(info.Size())
+		}
+		return nil
+	})
+	
+	if err != nil {
+		// If we can't calculate size, return nil
+		return nil
+	}
+	
+	return &totalSize
+}
+
+// createImageReference creates a storage reference for the root filesystem image
+func (p *RootFSProvider) createImageReference(originalRef, rootfsPath string) (storage.RegistryImageReference, error) {
+	// For root-fs images, we'll create a special reference that includes metadata
+	// The reference format will be: root-fs-provider://<path-hash>@<digest>
+	
+	pathDigest := digest.FromString(rootfsPath)
+	
+	// Create a reference that embeds the path information
+	// This allows the storage layer to know it's a root-fs image
+	refString := fmt.Sprintf("root-fs-provider://%s@%s", 
+		digest.FromString(originalRef).Encoded()[:12], // Short hash of original ref
+		pathDigest)
+	
+	imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData(refString)
+	if err != nil {
+		return storage.RegistryImageReference{}, fmt.Errorf("failed to parse root-fs image reference: %w", err)
+	}
+	
+	return imageRef, nil
+}

--- a/internal/imageprovider/rootfs_test.go
+++ b/internal/imageprovider/rootfs_test.go
@@ -1,0 +1,149 @@
+package imageprovider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestRootFSProvider_CanHandle(t *testing.T) {
+	provider := NewRootFSProvider([]string{})
+
+	tests := []struct {
+		name     string
+		imageSpec *criv1.ImageSpec
+		expected bool
+	}{
+		{
+			name: "root-fs scheme should be handled",
+			imageSpec: &criv1.ImageSpec{
+				Image: "root-fs:///opt/containers/my-image",
+			},
+			expected: true,
+		},
+		{
+			name: "docker scheme should not be handled",
+			imageSpec: &criv1.ImageSpec{
+				Image: "docker.io/library/nginx:latest",
+			},
+			expected: false,
+		},
+		{
+			name: "empty image spec should not be handled",
+			imageSpec: nil,
+			expected: false,
+		},
+		{
+			name: "empty image should not be handled",
+			imageSpec: &criv1.ImageSpec{
+				Image: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.CanHandle(tt.imageSpec)
+			if result != tt.expected {
+				t.Errorf("CanHandle() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRootFSProvider_PullImage(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "rootfs-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create some test content in the directory
+	testFile := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test content"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create provider with allowed paths
+	provider := NewRootFSProvider([]string{tempDir})
+
+	ctx := context.Background()
+	imageSpec := &criv1.ImageSpec{
+		Image: "root-fs://" + tempDir,
+	}
+
+	result, err := provider.PullImage(ctx, imageSpec, nil)
+	if err != nil {
+		t.Fatalf("PullImage failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("PullImage returned nil result")
+	}
+
+	// Check that the result contains expected metadata
+	if result.Metadata["rootfs.path"] != tempDir {
+		t.Errorf("Expected rootfs.path to be %s, got %s", tempDir, result.Metadata["rootfs.path"])
+	}
+
+	if result.Metadata["rootfs.original_ref"] != imageSpec.Image {
+		t.Errorf("Expected original_ref to be %s, got %s", imageSpec.Image, result.Metadata["rootfs.original_ref"])
+	}
+}
+
+func TestRootFSProvider_PullImage_InvalidPath(t *testing.T) {
+	provider := NewRootFSProvider([]string{})
+
+	ctx := context.Background()
+	imageSpec := &criv1.ImageSpec{
+		Image: "root-fs:///nonexistent/path",
+	}
+
+	_, err := provider.PullImage(ctx, imageSpec, nil)
+	if err == nil {
+		t.Fatal("Expected PullImage to fail for nonexistent path")
+	}
+}
+
+func TestRootFSProvider_PullImage_RestrictedPath(t *testing.T) {
+	// Create a temporary directory for testing
+	allowedDir, err := os.MkdirTemp("", "rootfs-allowed-*")
+	if err != nil {
+		t.Fatalf("Failed to create allowed temp dir: %v", err)
+	}
+	defer os.RemoveAll(allowedDir)
+
+	restrictedDir, err := os.MkdirTemp("", "rootfs-restricted-*")
+	if err != nil {
+		t.Fatalf("Failed to create restricted temp dir: %v", err)
+	}
+	defer os.RemoveAll(restrictedDir)
+
+	// Create provider with only one allowed path
+	provider := NewRootFSProvider([]string{allowedDir})
+
+	ctx := context.Background()
+
+	// This should succeed
+	allowedImageSpec := &criv1.ImageSpec{
+		Image: "root-fs://" + allowedDir,
+	}
+	_, err = provider.PullImage(ctx, allowedImageSpec, nil)
+	if err != nil {
+		t.Fatalf("Expected allowed path to succeed: %v", err)
+	}
+
+	// This should fail
+	restrictedImageSpec := &criv1.ImageSpec{
+		Image: "root-fs://" + restrictedDir,
+	}
+	_, err = provider.PullImage(ctx, restrictedImageSpec, nil)
+	if err == nil {
+		t.Fatal("Expected restricted path to fail")
+	}
+}

--- a/internal/imageprovider/service.go
+++ b/internal/imageprovider/service.go
@@ -1,0 +1,117 @@
+package imageprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/storage"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// Service manages image providers and routes image operations to the appropriate provider
+type Service struct {
+	registry *Registry
+}
+
+// NewService creates a new image provider service
+func NewService(imageService storage.ImageServer) *Service {
+	// Create registry with default provider
+	defaultProvider := NewDefaultProvider(imageService)
+	registry := NewRegistry(defaultProvider)
+	
+	return &Service{
+		registry: registry,
+	}
+}
+
+// RegisterProvider registers a new image provider
+func (s *Service) RegisterProvider(provider ImageProvider) {
+	s.registry.Register(provider)
+}
+
+// PullImage pulls an image using the appropriate provider
+func (s *Service) PullImage(ctx context.Context, imageSpec *criv1.ImageSpec, options *ImageProviderOptions) (*ImageProviderResult, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	provider := s.registry.FindProvider(imageSpec)
+	
+	log.Infof(ctx, "Using image provider %q for image %q", provider.Name(), imageSpec.GetImage())
+	
+	result, err := provider.PullImage(ctx, imageSpec, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull image with provider %q: %w", provider.Name(), err)
+	}
+	
+	return result, nil
+}
+
+// ImageStatus gets image status using the appropriate provider
+func (s *Service) ImageStatus(ctx context.Context, imageSpec *criv1.ImageSpec) (*ImageProviderResult, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	provider := s.registry.FindProvider(imageSpec)
+	
+	result, err := provider.ImageStatus(ctx, imageSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image status with provider %q: %w", provider.Name(), err)
+	}
+	
+	return result, nil
+}
+
+// RemoveImage removes an image using the appropriate provider
+func (s *Service) RemoveImage(ctx context.Context, imageSpec *criv1.ImageSpec) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	provider := s.registry.FindProvider(imageSpec)
+	
+	log.Infof(ctx, "Removing image %q using provider %q", imageSpec.GetImage(), provider.Name())
+	
+	err := provider.RemoveImage(ctx, imageSpec)
+	if err != nil {
+		return fmt.Errorf("failed to remove image with provider %q: %w", provider.Name(), err)
+	}
+	
+	return nil
+}
+
+// ListImages lists all images from all providers
+func (s *Service) ListImages(ctx context.Context) ([]*ImageProviderResult, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	var allResults []*ImageProviderResult
+	
+	// Get images from default provider
+	defaultResults, err := s.registry.defaultProvider.ListImages(ctx)
+	if err != nil {
+		log.Warnf(ctx, "Failed to list images from default provider: %v", err)
+	} else {
+		allResults = append(allResults, defaultResults...)
+	}
+	
+	// Get images from all registered providers
+	for _, provider := range s.registry.GetProviders() {
+		results, err := provider.ListImages(ctx)
+		if err != nil {
+			log.Warnf(ctx, "Failed to list images from provider %q: %v", provider.Name(), err)
+			continue
+		}
+		allResults = append(allResults, results...)
+	}
+	
+	return allResults, nil
+}
+
+// GetProviders returns information about all registered providers
+func (s *Service) GetProviders() []string {
+	names := []string{s.registry.defaultProvider.Name()}
+	for _, provider := range s.registry.GetProviders() {
+		names = append(names, provider.Name())
+	}
+	return names
+}

--- a/internal/imageprovider/service.go
+++ b/internal/imageprovider/service.go
@@ -115,3 +115,4 @@ func (s *Service) GetProviders() []string {
 	}
 	return names
 }
+

--- a/internal/imageprovider/util.go
+++ b/internal/imageprovider/util.go
@@ -1,0 +1,94 @@
+package imageprovider
+
+import (
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
+	imageTypes "github.com/containers/image/v5/types"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// parseImageSpecToReference converts a CRI ImageSpec to internal RegistryImageReference
+func parseImageSpecToReference(imageSpec *criv1.ImageSpec) (storage.RegistryImageReference, error) {
+	if imageSpec == nil {
+		return storage.RegistryImageReference{}, fmt.Errorf("imageSpec cannot be nil")
+	}
+	
+	image := imageSpec.GetImage()
+	if image == "" {
+		return storage.RegistryImageReference{}, fmt.Errorf("image field cannot be empty")
+	}
+	
+	// Parse the image reference using the existing CRI-O logic
+	imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData(image)
+	if err != nil {
+		return storage.RegistryImageReference{}, fmt.Errorf("failed to parse image reference %q: %w", image, err)
+	}
+	
+	return imageRef, nil
+}
+
+// convertToImageCopyOptions converts ImageProviderOptions to storage.ImageCopyOptions
+func convertToImageCopyOptions(options *ImageProviderOptions) *storage.ImageCopyOptions {
+	if options == nil {
+		return &storage.ImageCopyOptions{}
+	}
+	
+	copyOptions := &storage.ImageCopyOptions{
+		SourceCtx:      options.SystemContext,
+		DestinationCtx: options.SystemContext,
+	}
+	
+	// Convert auth config if provided
+	if options.Auth != nil {
+		copyOptions.SourceCtx = &imageTypes.SystemContext{}
+		if options.SystemContext != nil {
+			*copyOptions.SourceCtx = *options.SystemContext // shallow copy
+		}
+		
+		if options.Auth.Username != "" || options.Auth.Password != "" {
+			copyOptions.SourceCtx.DockerAuthConfig = &imageTypes.DockerAuthConfig{
+				Username: options.Auth.Username,
+				Password: options.Auth.Password,
+			}
+		}
+	}
+	
+	// Set up progress callback if provided
+	if options.ProgressCallback != nil {
+		// Create a channel for progress and start a goroutine to forward it
+		progress := make(chan imageTypes.ProgressProperties)
+		copyOptions.Progress = progress
+		
+		go func() {
+			for p := range progress {
+				options.ProgressCallback(p)
+			}
+		}()
+	}
+	
+	return copyOptions
+}
+
+// convertImageResultToResult converts storage.ImageResult to ImageProviderResult
+func convertImageResultToResult(imageResult *storage.ImageResult) *ImageProviderResult {
+	if imageResult == nil {
+		return nil
+	}
+	
+	result := &ImageProviderResult{
+		Size:   imageResult.Size,
+		Digest: imageResult.Digest.String(),
+		Labels: imageResult.Labels,
+		Metadata: map[string]string{
+			"provider": "default",
+		},
+	}
+	
+	if imageResult.SomeNameOfThisImage != nil {
+		result.ImageRef = *imageResult.SomeNameOfThisImage
+	}
+	
+	return result
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -622,6 +622,28 @@ type ImageConfig struct {
 	// If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 	// If "disabled", the first result will be chosen.
 	ShortNameMode string `toml:"short_name_mode"`
+	
+	// ImageProviders contains configuration for pluggable image providers
+	ImageProviders ImageProvidersConfig `toml:"image_providers"`
+}
+
+// ImageProvidersConfig contains configuration for image providers
+type ImageProvidersConfig struct {
+	// EnablePluggableProviders enables the pluggable image provider system
+	EnablePluggableProviders bool `toml:"enable_pluggable_providers"`
+	
+	// RootFS contains configuration for the root filesystem provider
+	RootFS RootFSProviderConfig `toml:"rootfs"`
+}
+
+// RootFSProviderConfig contains configuration for the root filesystem provider
+type RootFSProviderConfig struct {
+	// Enable enables the root filesystem provider
+	Enable bool `toml:"enable"`
+	
+	// AllowedPaths is a list of allowed base paths for root filesystem images
+	// If empty, any absolute path is allowed (not recommended for production)
+	AllowedPaths []string `toml:"allowed_paths"`
 }
 
 // NetworkConfig represents the "crio.network" TOML config table.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -564,6 +564,21 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: simpleEqual(dc.OCIArtifactMountSupport, c.OCIArtifactMountSupport),
 		},
 		{
+			templateString: templateStringCrioImageProvidersEnablePluggable,
+			group:          crioImageConfig,
+			isDefaultValue: simpleEqual(dc.ImageProviders.EnablePluggableProviders, c.ImageProviders.EnablePluggableProviders),
+		},
+		{
+			templateString: templateStringCrioImageProvidersRootFSEnable,
+			group:          crioImageConfig,
+			isDefaultValue: simpleEqual(dc.ImageProviders.RootFS.Enable, c.ImageProviders.RootFS.Enable),
+		},
+		{
+			templateString: templateStringCrioImageProvidersRootFSAllowedPaths,
+			group:          crioImageConfig,
+			isDefaultValue: slices.Equal(dc.ImageProviders.RootFS.AllowedPaths, c.ImageProviders.RootFS.AllowedPaths),
+		},
+		{
 			templateString: templateStringCrioNetworkCniDefaultNetwork,
 			group:          crioNetworkConfig,
 			isDefaultValue: simpleEqual(dc.CNIDefaultNetwork, c.CNIDefaultNetwork),
@@ -1544,6 +1559,28 @@ const templateStringCrioImageShortNameMode = `# The mode of short name resolutio
 # If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 # If "disabled", the first result will be chosen.
 {{ $.Comment }}short_name_mode = "{{ .ShortNameMode }}"
+
+`
+
+const templateStringCrioImageProvidersEnablePluggable = `# Enable pluggable image providers for handling different image types.
+# When enabled, allows using custom image providers like root filesystem directories.
+{{ $.Comment }}[crio.image.image_providers]
+{{ $.Comment }}enable_pluggable_providers = {{ .ImageProviders.EnablePluggableProviders }}
+
+`
+
+const templateStringCrioImageProvidersRootFSEnable = `# Enable the root filesystem image provider for handling root-fs:// image references.
+# This allows containers to use local filesystem directories directly as root filesystems.
+{{ $.Comment }}[crio.image.image_providers.rootfs]
+{{ $.Comment }}enable = {{ .ImageProviders.RootFS.Enable }}
+
+`
+
+const templateStringCrioImageProvidersRootFSAllowedPaths = `# List of allowed base paths for root filesystem images.
+# If empty, any absolute path is allowed (not recommended for production).
+# Example: ["/opt/containers", "/var/lib/images"]
+{{ $.Comment }}{{ if .ImageProviders.RootFS.AllowedPaths }}allowed_paths = [
+{{ range $path := .ImageProviders.RootFS.AllowedPaths }}{{ $.Comment }}{{ printf "\t%q,\n" $path }}{{ end }}{{ $.Comment }}]{{ end }}
 
 `
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -520,6 +521,27 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 
 		return nil
 	})
+
+	// Check if this is a root-fs:// image that should bypass containers/storage
+	userRequestedImage, err := ctr.UserRequestedImage()
+	if err != nil {
+		return nil, err
+	}
+	
+	if s.isRootFSImage(userRequestedImage) {
+		log.Infof(ctx, "Detected root-fs image: %s", userRequestedImage)
+		ociContainer, err := s.createRootFSContainer(ctx, req, sb, ctr, userRequestedImage)
+		if err != nil {
+			return nil, err
+		}
+		
+		// Add the container to the server's tracking
+		s.addContainer(ctx, ociContainer)
+		
+		return &types.CreateContainerResponse{
+			ContainerId: ociContainer.ID(),
+		}, nil
+	}
 
 	newContainer, err := s.createSandboxContainer(ctx, ctr, sb)
 	if err != nil {
@@ -1488,4 +1510,422 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 	}
 
 	return nil
+}
+
+// isRootFSImage checks if the given image reference is a root-fs:// image
+func (s *Server) isRootFSImage(imageRef string) bool {
+	return strings.HasPrefix(imageRef, "root-fs://")
+}
+
+// extractRootFSPath extracts the filesystem path from a root-fs:// URL  
+func (s *Server) extractRootFSPath(imageRef string) (string, error) {
+	if !s.isRootFSImage(imageRef) {
+		return "", fmt.Errorf("not a root-fs image: %s", imageRef)
+	}
+	
+	path := strings.TrimPrefix(imageRef, "root-fs://")
+	if path == "" {
+		return "", fmt.Errorf("empty path in root-fs reference: %s", imageRef)
+	}
+	
+	// Clean and validate the path
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("root-fs path must be absolute: %s", path)
+	}
+	
+	return path, nil
+}
+
+// validateRootFSPath validates that the root filesystem path is accessible and appears to be a valid rootfs
+func (s *Server) validateRootFSPath(ctx context.Context, rootfsPath string) error {
+	// Check if enabled and path is allowed
+	if s.imageProviderService != nil && s.config.ImageProviders.RootFS.Enable {
+		// Validate against allowed paths if configured
+		if len(s.config.ImageProviders.RootFS.AllowedPaths) > 0 {
+			allowed := false
+			cleanPath := filepath.Clean(rootfsPath)
+			
+			for _, allowedPath := range s.config.ImageProviders.RootFS.AllowedPaths {
+				cleanAllowed := filepath.Clean(allowedPath)
+				if strings.HasPrefix(cleanPath, cleanAllowed) {
+					allowed = true
+					break
+				}
+			}
+			
+			if !allowed {
+				return fmt.Errorf("root-fs path not allowed: %s (allowed paths: %v)", rootfsPath, s.config.ImageProviders.RootFS.AllowedPaths)
+			}
+		}
+	} else {
+		return fmt.Errorf("root-fs image provider is not enabled")
+	}
+	
+	// Check if path exists and is a directory
+	info, err := os.Stat(rootfsPath)
+	if err != nil {
+		return fmt.Errorf("root-fs path does not exist: %w", err)
+	}
+	
+	if !info.IsDir() {
+		return fmt.Errorf("root-fs path is not a directory: %s", rootfsPath)
+	}
+	
+	// Check for basic rootfs structure (optional validation)
+	requiredDirs := []string{"bin", "etc", "usr"}
+	for _, dir := range requiredDirs {
+		dirPath := filepath.Join(rootfsPath, dir)
+		if info, err := os.Stat(dirPath); err != nil || !info.IsDir() {
+			log.Warnf(ctx, "Root filesystem %s missing standard directory %s - may not be a valid rootfs", rootfsPath, dir)
+		}
+	}
+	
+	log.Infof(ctx, "Validated root-fs path: %s", rootfsPath)
+	return nil
+}
+
+// createRootFSContainer creates a container using a direct root filesystem path
+// This bypasses containers/storage and uses the filesystem directly
+func (s *Server) createRootFSContainer(ctx context.Context, req *types.CreateContainerRequest, sb *sandbox.Sandbox, ctr container.Container, userRequestedImage string) (*oci.Container, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	// Extract and validate the root filesystem path
+	rootfsPath, err := s.extractRootFSPath(userRequestedImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract root-fs path: %w", err)
+	}
+	
+	// Validate the root filesystem path
+	if err := s.validateRootFSPath(ctx, rootfsPath); err != nil {
+		return nil, fmt.Errorf("root-fs path validation failed: %w", err)
+	}
+	
+	log.Infof(ctx, "Creating container %s with root filesystem: %s", ctr.ID(), rootfsPath)
+	
+	containerConfig := req.GetConfig()
+	metadata := containerConfig.GetMetadata()
+	
+	// Set up container directories similar to normal containers but simpler
+	containerInfo, err := s.createRootFSContainerInfo(ctx, ctr, sb, rootfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container info: %w", err)
+	}
+	
+	// Generate OCI runtime specification with direct rootfs
+	specgen, err := s.createRootFSSpec(ctx, containerConfig, sb, containerInfo, rootfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCI spec: %w", err)
+	}
+	
+	// Set up logging path
+	logPath, err := ctr.LogPath(sb.LogDir())
+	if err != nil {
+		return nil, err
+	}
+	
+	// Create container labels and annotations
+	labels := containerConfig.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	
+	annotations := containerConfig.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	
+	// Mark this as a root-fs container for identification
+	labels["io.cri-o.image.type"] = "root-fs"
+	annotations["io.cri-o.image.rootfs.path"] = rootfsPath
+	
+	// Create fake image references for compatibility with existing code
+	imageID := storage.StorageImageID{} // Empty image ID for root-fs
+	someNameOfTheImage := &storage.RegistryImageReference{} // Empty registry reference
+	someRepoDigest := fmt.Sprintf("root-fs@sha256:%x", sha256.Sum256([]byte(rootfsPath)))
+	
+	// Create container metadata for CRI
+	criMetadata := &types.ContainerMetadata{
+		Name:    metadata.GetName(),
+		Attempt: metadata.GetAttempt(),
+	}
+	
+	// Determine stop signal (default to SIGTERM)
+	stopSignal := "SIGTERM"
+	if containerConfig.GetLinux() != nil && containerConfig.GetLinux().GetSecurityContext() != nil {
+		// Use any configured stop signal or default
+		stopSignal = "SIGTERM"
+	}
+	
+	// Create OCI container
+	created := time.Now()
+	ociContainer, err := oci.NewContainer(
+		ctr.ID(),
+		ctr.Name(),
+		containerInfo.RunDir,
+		logPath,
+		labels,
+		annotations,
+		containerConfig.GetAnnotations(),
+		userRequestedImage,           // userRequestedImage
+		someNameOfTheImage,          // someNameOfTheImage
+		&imageID,                    // imageID  
+		someRepoDigest,              // someRepoDigest
+		criMetadata,
+		sb.ID(),
+		containerConfig.GetTty(),
+		containerConfig.GetStdin(),
+		containerConfig.GetStdinOnce(),
+		sb.RuntimeHandler(),
+		containerInfo.Dir,
+		created,
+		stopSignal,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCI container: %w", err)
+	}
+	
+	// Set the OCI spec and mount point
+	ociContainer.SetSpec(specgen.Config)
+	ociContainer.SetMountPoint(rootfsPath) // Use direct path as mount point
+	
+	log.Infof(ctx, "Successfully created root-fs container %s using %s", ctr.ID(), rootfsPath)
+	
+	return ociContainer, nil
+}
+
+// RootFSContainerInfo holds information for a root-fs container
+type RootFSContainerInfo struct {
+	Dir      string // Container work directory
+	RunDir   string // Container run directory 
+	RootPath string // Direct root filesystem path
+}
+
+// createRootFSContainerInfo creates container directory structure for root-fs containers
+func (s *Server) createRootFSContainerInfo(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, rootfsPath string) (*RootFSContainerInfo, error) {
+	// Create container directories similar to regular containers
+	containerDir := filepath.Join(s.config.Root, "containers", ctr.ID())
+	if err := os.MkdirAll(containerDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create container directory: %w", err)
+	}
+	
+	runDir := filepath.Join(s.config.RunRoot, "containers", ctr.ID())  
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create container run directory: %w", err)
+	}
+	
+	// Create subdirectories
+	subdirs := []string{"userdata", "mounts"}
+	for _, subdir := range subdirs {
+		subdirPath := filepath.Join(containerDir, subdir)
+		if err := os.MkdirAll(subdirPath, 0o700); err != nil {
+			return nil, fmt.Errorf("failed to create container subdirectory %s: %w", subdir, err)
+		}
+	}
+	
+	return &RootFSContainerInfo{
+		Dir:      containerDir,
+		RunDir:   runDir, 
+		RootPath: rootfsPath,
+	}, nil
+}
+
+// createRootFSSpec creates an OCI runtime specification for root-fs containers
+func (s *Server) createRootFSSpec(ctx context.Context, containerConfig *types.ContainerConfig, sb *sandbox.Sandbox, containerInfo *RootFSContainerInfo, rootfsPath string) (*generate.Generator, error) {
+	// Create a new OCI spec generator
+	specgen, err := generate.New("linux")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create spec generator: %w", err)
+	}
+	
+	// Set root filesystem to the direct path - this is the key difference!
+	specgen.SetRootPath(rootfsPath)
+	specgen.SetRootReadonly(containerConfig.GetLinux().GetSecurityContext().GetReadonlyRootfs())
+	
+	// Set process configuration
+	if containerConfig.Command != nil && len(containerConfig.Command) > 0 {
+		specgen.SetProcessArgs(containerConfig.Command)
+	} else {
+		// Default command if none specified
+		specgen.SetProcessArgs([]string{"/bin/sh"})
+	}
+	
+	// Set working directory
+	if containerConfig.WorkingDir != "" {
+		specgen.SetProcessCwd(containerConfig.WorkingDir)
+	} else {
+		specgen.SetProcessCwd("/")
+	}
+	
+	// Set environment variables
+	if containerConfig.Envs != nil {
+		for _, env := range containerConfig.Envs {
+			specgen.AddProcessEnv(env.Key, env.Value)
+		}
+	}
+	
+	// Set hostname from sandbox
+	specgen.SetHostname(sb.Hostname())
+	
+	// Configure user and groups  
+	securityContext := containerConfig.GetLinux().GetSecurityContext()
+	if securityContext != nil {
+		if securityContext.GetRunAsUser() != nil {
+			uid := securityContext.GetRunAsUser().Value
+			specgen.SetProcessUID(uint32(uid))
+		}
+		
+		if securityContext.GetRunAsGroup() != nil {
+			gid := securityContext.GetRunAsGroup().Value
+			specgen.SetProcessGID(uint32(gid))
+		}
+		
+		// Set supplemental groups
+		if securityContext.GetSupplementalGroups() != nil {
+			for _, group := range securityContext.GetSupplementalGroups() {
+				specgen.AddProcessAdditionalGid(uint32(group))
+			}
+		}
+	}
+	
+	// Add essential mounts (proc, sys, dev, etc.)
+	s.addRootFSMounts(&specgen, containerConfig, sb)
+	
+	// Configure namespaces - join sandbox namespaces
+	s.configureRootFSNamespaces(&specgen, sb)
+	
+	// Set up security context (capabilities, etc.)
+	if securityContext != nil {
+		s.configureRootFSSecurity(&specgen, securityContext)
+	}
+	
+	return &specgen, nil
+}
+
+// addRootFSMounts adds essential mounts for root-fs containers
+func (s *Server) addRootFSMounts(specgen *generate.Generator, containerConfig *types.ContainerConfig, sb *sandbox.Sandbox) {
+	// Add proc filesystem
+	specgen.AddMount(rspec.Mount{
+		Source:      "proc",
+		Destination: "/proc", 
+		Type:        "proc",
+		Options:     []string{"nosuid", "noexec", "nodev"},
+	})
+	
+	// Add sys filesystem (read-only)
+	specgen.AddMount(rspec.Mount{
+		Source:      "sysfs",
+		Destination: "/sys",
+		Type:        "sysfs", 
+		Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+	})
+	
+	// Add dev filesystem
+	specgen.AddMount(rspec.Mount{
+		Source:      "tmpfs",
+		Destination: "/dev",
+		Type:        "tmpfs",
+		Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+	})
+	
+	// Add CRI mounts specified in container config
+	if containerConfig.Mounts != nil {
+		for _, mount := range containerConfig.Mounts {
+			opts := []string{"bind"}
+			if mount.Readonly {
+				opts = append(opts, "ro")
+			} else {
+				opts = append(opts, "rw")
+			}
+			
+			specgen.AddMount(rspec.Mount{
+				Source:      mount.HostPath,
+				Destination: mount.ContainerPath,
+				Type:        "bind",
+				Options:     opts,
+			})
+		}
+	}
+	
+	// Add sandbox files (resolv.conf, hostname, etc.) if available
+	options := []string{"rw", "bind", "nodev", "nosuid", "noexec"}
+	
+	if sb.ResolvPath() != "" {
+		specgen.AddMount(rspec.Mount{
+			Source:      sb.ResolvPath(),
+			Destination: "/etc/resolv.conf",
+			Type:        "bind",
+			Options:     options,
+		})
+	}
+	
+	if sb.HostnamePath() != "" {
+		specgen.AddMount(rspec.Mount{
+			Source:      sb.HostnamePath(), 
+			Destination: "/etc/hostname",
+			Type:        "bind",
+			Options:     options,
+		})
+	}
+}
+
+// configureRootFSNamespaces configures namespaces for root-fs containers
+func (s *Server) configureRootFSNamespaces(specgen *generate.Generator, sb *sandbox.Sandbox) {
+	// Share network, IPC, and UTS namespaces with the sandbox (standard CRI behavior)
+	if sb.InfraContainer() != nil && sb.InfraContainer().State() != nil {
+		infraPid := sb.InfraContainer().State().Pid
+		
+		// Join network namespace
+		specgen.AddOrReplaceLinuxNamespace("network", fmt.Sprintf("/proc/%d/ns/net", infraPid))
+		
+		// Join IPC namespace
+		specgen.AddOrReplaceLinuxNamespace("ipc", fmt.Sprintf("/proc/%d/ns/ipc", infraPid))
+		
+		// Join UTS namespace (hostname)
+		specgen.AddOrReplaceLinuxNamespace("uts", fmt.Sprintf("/proc/%d/ns/uts", infraPid))
+	}
+	
+	// Create new PID and mount namespaces for isolation
+	specgen.AddOrReplaceLinuxNamespace("pid", "")
+	specgen.AddOrReplaceLinuxNamespace("mount", "")
+}
+
+// configureRootFSSecurity configures security settings for root-fs containers
+func (s *Server) configureRootFSSecurity(specgen *generate.Generator, securityContext *types.LinuxContainerSecurityContext) {
+	// Handle capabilities
+	if securityContext.Capabilities != nil {
+		// Add capabilities
+		if securityContext.Capabilities.AddCapabilities != nil {
+			for _, cap := range securityContext.Capabilities.AddCapabilities {
+				specgen.AddProcessCapabilityBounding(cap)
+				specgen.AddProcessCapabilityEffective(cap)
+				specgen.AddProcessCapabilityInheritable(cap)
+				specgen.AddProcessCapabilityPermitted(cap)
+			}
+		}
+		
+		// Drop capabilities
+		if securityContext.Capabilities.DropCapabilities != nil {
+			for _, cap := range securityContext.Capabilities.DropCapabilities {
+				specgen.DropProcessCapabilityBounding(cap)
+				specgen.DropProcessCapabilityEffective(cap)
+				specgen.DropProcessCapabilityInheritable(cap)
+				specgen.DropProcessCapabilityPermitted(cap)
+			}
+		}
+	}
+	
+	// Handle privileged containers
+	if securityContext.GetPrivileged() {
+		specgen.SetupPrivileged(true)
+	}
+	
+	// Set SELinux labels if configured
+	if securityContext.GetSelinuxOptions() != nil {
+		selinuxOpts := securityContext.GetSelinuxOptions()
+		if selinuxOpts.GetType() != "" {
+			specgen.SetProcessSelinuxLabel(selinuxOpts.GetType())
+		}
+	}
 }

--- a/server/image_provider_integration.go
+++ b/server/image_provider_integration.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/imageprovider"
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/storage"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+)
+
+// initializeImageProviderService sets up the pluggable image provider system
+func (s *Server) initializeImageProviderService(ctx context.Context, config *libconfig.Config, imageService storage.ImageServer) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	
+	// Check if pluggable providers are enabled
+	if !config.ImageProviders.EnablePluggableProviders {
+		log.Infof(ctx, "Pluggable image providers are disabled")
+		s.imageProviderService = nil
+		return nil
+	}
+	
+	log.Infof(ctx, "Initializing pluggable image provider service")
+	
+	// Create the image provider service
+	s.imageProviderService = imageprovider.NewService(imageService)
+	
+	// Register root filesystem provider if enabled
+	if config.ImageProviders.RootFS.Enable {
+		log.Infof(ctx, "Enabling root filesystem image provider with allowed paths: %v", config.ImageProviders.RootFS.AllowedPaths)
+		rootfsProvider := imageprovider.NewRootFSProvider(config.ImageProviders.RootFS.AllowedPaths)
+		s.imageProviderService.RegisterProvider(rootfsProvider)
+	}
+	
+	providers := s.imageProviderService.GetProviders()
+	log.Infof(ctx, "Image provider service initialized with providers: %v", providers)
+	
+	return nil
+}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -18,6 +18,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	crierrors "k8s.io/cri-api/pkg/errors"
 
+	"github.com/cri-o/cri-o/internal/imageprovider"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/server/metrics"
@@ -28,7 +29,57 @@ import (
 func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*types.PullImageResponse, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
-	// TODO: what else do we need here? (Signatures when the story isn't just pulling from docker://)
+	
+	img := req.GetImage()
+	if img == nil {
+		return nil, fmt.Errorf("image specification is required")
+	}
+
+	image := img.GetImage()
+	if image == "" {
+		return nil, fmt.Errorf("image field cannot be empty")
+	}
+
+	log.Infof(ctx, "Pulling image: %s", image)
+
+	// Use image provider service if available, otherwise fall back to legacy method
+	if s.imageProviderService != nil {
+		return s.pullImageWithProviders(ctx, req)
+	}
+
+	// Legacy path - keep existing functionality for backward compatibility
+	return s.pullImageLegacy(ctx, req)
+}
+
+// pullImageWithProviders uses the pluggable image provider system
+func (s *Server) pullImageWithProviders(ctx context.Context, req *types.PullImageRequest) (*types.PullImageResponse, error) {
+	img := req.GetImage()
+	
+	// Create provider options
+	options := &imageprovider.ImageProviderOptions{
+		Auth: req.GetAuth(),
+		PodSandboxConfig: req.GetSandboxConfig(),
+		SystemContext: s.config.SystemContext,
+	}
+
+	// Pull using image provider service
+	result, err := s.imageProviderService.PullImage(ctx, img, options)
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return nil, fmt.Errorf("%w: %w", crierrors.ErrRegistryUnavailable, err)
+		}
+		return nil, storage.WrapSignatureCRIErrorIfNeeded(err)
+	}
+
+	log.Infof(ctx, "Pulled image: %v", result.ImageRef)
+
+	return &types.PullImageResponse{
+		ImageRef: result.ImageRef.StringForOutOfProcessConsumptionOnly(),
+	}, nil
+}
+
+// pullImageLegacy maintains the original pull behavior for backward compatibility
+func (s *Server) pullImageLegacy(ctx context.Context, req *types.PullImageRequest) (*types.PullImageResponse, error) {
 	var err error
 
 	image := ""
@@ -38,7 +89,7 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 		image = img.GetImage()
 	}
 
-	log.Infof(ctx, "Pulling image: %s", image)
+	log.Infof(ctx, "Pulling image (legacy): %s", image)
 
 	pullArgs := pullArguments{image: image}
 

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -8,6 +8,7 @@ import (
 	storagetypes "github.com/containers/storage"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/cri-o/cri-o/internal/imageprovider"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/ociartifact"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -15,21 +16,24 @@ import (
 
 // RemoveImage removes the image.
 func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest) (*types.RemoveImageResponse, error) {
+	_ = (*imageprovider.Service)(nil) // Force import usage
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	imageRef := ""
 	img := req.GetImage()
-
-	if img != nil {
-		imageRef = img.GetImage()
-	}
-
-	if imageRef == "" {
+	if img == nil || img.GetImage() == "" {
 		return nil, errors.New("no image specified")
 	}
 
-	if err := s.removeImage(ctx, imageRef); err != nil {
+	log.Infof(ctx, "Removing image: %s", img.GetImage())
+
+	// Use image provider service if available
+	if s.imageProviderService != nil {
+		return s.removeImageWithProviders(ctx, req)
+	}
+
+	// Legacy path
+	if err := s.removeImage(ctx, img.GetImage()); err != nil {
 		return nil, err
 	}
 
@@ -143,4 +147,20 @@ func (s *Server) volumeInUse(digest string) error {
 	}
 
 	return nil
+}
+
+// removeImageWithProviders uses the pluggable image provider system for image removal
+func (s *Server) removeImageWithProviders(ctx context.Context, req *types.RemoveImageRequest) (*types.RemoveImageResponse, error) {
+	img := req.GetImage()
+	
+	// Try to remove using image provider service
+	err := s.imageProviderService.RemoveImage(ctx, img)
+	if err != nil {
+		// Fall back to legacy behavior for compatibility
+		if err := s.removeImage(ctx, img.GetImage()); err != nil {
+			return nil, err
+		}
+	}
+	
+	return &types.RemoveImageResponse{}, nil
 }

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -13,6 +13,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/cri-o/cri-o/internal/imageprovider"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/ociartifact"
 	pkgstorage "github.com/cri-o/cri-o/internal/storage"
@@ -20,6 +21,7 @@ import (
 
 // ImageStatus returns the status of the image.
 func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest) (*types.ImageStatusResponse, error) {
+	_ = (*imageprovider.Service)(nil) // Force import usage
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -30,6 +32,12 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 
 	log.Infof(ctx, "Checking image status: %s", img.GetImage())
 
+	// Use image provider service if available
+	if s.imageProviderService != nil {
+		return s.imageStatusWithProviders(ctx, req)
+	}
+
+	// Legacy path
 	status, err := s.storageImageStatus(ctx, img)
 	if err != nil {
 		return nil, err
@@ -181,4 +189,114 @@ func createImageInfo(result *pkgstorage.ImageResult) (map[string]string, error) 
 	}
 
 	return map[string]string{"info": string(bytes)}, nil
+}
+
+// imageStatusWithProviders uses the pluggable image provider system for image status
+func (s *Server) imageStatusWithProviders(ctx context.Context, req *types.ImageStatusRequest) (*types.ImageStatusResponse, error) {
+	img := req.GetImage()
+	
+	// Try to get status using image provider service
+	result, err := s.imageProviderService.ImageStatus(ctx, img)
+	if err != nil {
+		// Fall back to legacy behavior for compatibility
+		return s.imageStatusLegacy(ctx, req)
+	}
+	
+	// Convert provider result to CRI response
+	response := &types.ImageStatusResponse{
+		Image: &types.Image{
+			Id:          result.Digest,
+			RepoTags:    []string{img.GetImage()},
+			RepoDigests: []string{result.ImageRef.StringForOutOfProcessConsumptionOnly()},
+			Size:        0, // Size will be set below if available
+		},
+	}
+	
+	if result.Size != nil {
+		response.Image.Size = *result.Size
+	}
+	
+	// Add verbose info if requested
+	if req.GetVerbose() {
+		info := map[string]string{
+			"provider": "pluggable",
+		}
+		
+		// Add metadata from provider
+		for k, v := range result.Metadata {
+			info[k] = v
+		}
+		
+		response.Info = info
+	}
+	
+	return response, nil
+}
+
+// imageStatusLegacy provides the original image status behavior
+func (s *Server) imageStatusLegacy(ctx context.Context, req *types.ImageStatusRequest) (*types.ImageStatusResponse, error) {
+	img := req.GetImage()
+	
+	status, err := s.storageImageStatus(ctx, img)
+	if err != nil {
+		return nil, err
+	}
+
+	if status == nil {
+		artifact, err := s.ArtifactStore().Status(ctx, img.GetImage())
+		if err == nil {
+			return &types.ImageStatusResponse{
+				Image: artifact.CRIImage(),
+			}, nil
+		}
+
+		if errors.Is(err, ociartifact.ErrNotFound) {
+			log.Infof(ctx, "Neither image nor artifact %s found", img.GetImage())
+		} else if err != nil {
+			log.Errorf(ctx, "Unable to get artifact: %v", err)
+		}
+
+		return &types.ImageStatusResponse{}, nil
+	}
+
+	imageID, ref := status.ID.IDStringForOutOfProcessConsumptionOnly(), status.RepoDigests
+	if len(status.RepoTags) == 0 && len(status.RepoDigests) == 0 {
+		// In this case set the image ID to the ID itself with digest prefix and the ref to empty.
+		imageID = storage.ImageDigestBigDataKey + ":" + status.ID.IDStringForOutOfProcessConsumptionOnly()
+		ref = []string{}
+	}
+
+	var UID *int64
+	var username string
+	if status.User != "" {
+		UID, username = getUserFromImage(status.User)
+	}
+
+	response := &types.ImageStatusResponse{
+		Image: &types.Image{
+			Id:          imageID,
+			RepoTags:    status.RepoTags,
+			RepoDigests: ref,
+			Size:        0,
+			Uid:         &types.Int64Value{Value: 0},
+			Username:    username,
+			Spec:        img,
+		},
+	}
+	if status.Size != nil {
+		response.Image.Size = *status.Size
+	}
+	if UID != nil {
+		response.Image.Uid.Value = *UID
+	}
+
+	if req.GetVerbose() {
+		info, err := createImageInfo(status)
+		if err != nil {
+			return nil, fmt.Errorf("create image info: %w", err)
+		}
+		response.Info = info
+	}
+
+	return response, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cri-o/cri-o/internal/cert"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	"github.com/cri-o/cri-o/internal/hostport"
+	"github.com/cri-o/cri-o/internal/imageprovider"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -94,6 +95,9 @@ type Server struct {
 	nri *nriAPI
 	// hooksRetriever allows getting the runtime hooks for the sandboxes.
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
+
+	// imageProviderService manages pluggable image providers
+	imageProviderService *imageprovider.Service
 
 	types.UnsafeImageServiceServer
 	types.UnsafeRuntimeServiceServer
@@ -596,6 +600,11 @@ func New(
 
 	if err := s.nri.start(); err != nil {
 		return nil, err
+	}
+
+	// Initialize image provider service
+	if err := s.initializeImageProviderService(ctx, config, s.ContainerServer.StorageImageServer()); err != nil {
+		return nil, fmt.Errorf("initialize image provider service: %w", err)
 	}
 
 	if err := watchdog.New(s.checkCRIHealth).Start(ctx); err != nil {


### PR DESCRIPTION
Implements a pluggable architecture for handling different image types in CRI-O, starting with root filesystem directories as container images.

New Features:
- ImageProvider interface for pluggable image sources
- RootFS provider for root-fs:// scheme URLs
- Configuration support via [crio.image.image_providers] section
- Security controls with allowed_paths restrictions
- Backward compatibility with existing image handling

Components Added:
- internal/imageprovider/ - Core provider system
- server/image_provider_integration.go - Server integration
- Configuration templates and validation
- Documentation and examples

Modified Components:
- Enhanced image operations (pull/status/remove) with provider routing
- Server initialization with provider service setup
- Configuration system extended with image provider settings

The system allows using local filesystem directories as container images:
  image: 'root-fs:///opt/my-containers/my-app'

Maintains full backward compatibility and provides clean extensibility for future image source types.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
